### PR TITLE
Updated with requested changes and refactored package naming

### DIFF
--- a/src/main/java/frc/team2412/robot/Controls.java
+++ b/src/main/java/frc/team2412/robot/Controls.java
@@ -1,7 +1,7 @@
 package frc.team2412.robot;
 
 import org.frcteam2910.common.robot.input.XboxController;
-import static frc.team2412.robot.Subsystems.SubsystemConstants.*;
+import static frc.team2412.robot.SubsystemContainer.SubsystemConstants.*;
 
 public class Controls {
     public static class ControlConstants{
@@ -10,9 +10,9 @@ public class Controls {
 
     public XboxController controller;
 
-    public Subsystems subsystems;
+    public SubsystemContainer subsystems;
 
-    public Controls(Subsystems s){
+    public Controls(SubsystemContainer s){
         subsystems = s;
         controller = new XboxController(ControlConstants.CONTROLLER_PORT);
         if(CLIMB_ENABLED) bindClimbControls();

--- a/src/main/java/frc/team2412/robot/Robot.java
+++ b/src/main/java/frc/team2412/robot/Robot.java
@@ -19,13 +19,13 @@ public class Robot extends TimedRobot {
 
 
   public final Controls controls;
-  public final Subsystems subsystems;
+  public final SubsystemContainer subsystems;
   public final Hardware hardware;
 
   private Robot(){
       instance = this;
       hardware = new Hardware();
-      subsystems = new Subsystems(hardware);
+      subsystems = new SubsystemContainer(hardware);
       controls = new Controls(subsystems);
   }
 

--- a/src/main/java/frc/team2412/robot/SubsystemContainer.java
+++ b/src/main/java/frc/team2412/robot/SubsystemContainer.java
@@ -1,17 +1,17 @@
 package frc.team2412.robot;
 
-import frc.team2412.robot.subsystems.*;
+import static frc.team2412.robot.SubsystemContainer.SubsystemConstants.*;
 
-import static frc.team2412.robot.Subsystems.SubsystemConstants.*;
+import frc.team2412.robot.Subsystems.*;
 
-public class Subsystems {
+public class SubsystemContainer {
     public static class SubsystemConstants {
         public static final boolean CLIMB_ENABLED = false;
         public static final boolean DRIVE_ENABLED = false;
         public static final boolean FRONT_VIS_ENABLED = false;
         public static final boolean GOAL_VIS_ENABLED = false;
         public static final boolean INDEX_ENABLED = false;
-        public static final boolean INTAKE_ENABLED = false;
+        public static final boolean INTAKE_ENABLED = false; 
         public static final boolean SHOOTER_ENABLED = false;
 
 
@@ -32,7 +32,7 @@ public class Subsystems {
 
     public ShooterSubsystem shooterSubsystem;
 
-    public Subsystems(Hardware h){
+    public SubsystemContainer(Hardware h){
         hardware = h;
         if(CLIMB_ENABLED) climbSubsystem = new ClimbSubsystem();
         if(DRIVE_ENABLED) drivebaseSubsystem = new DrivebaseSubsystem();

--- a/src/main/java/frc/team2412/robot/subsystems/ClimbSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/ClimbSubsystem.java
@@ -1,4 +1,4 @@
-package frc.team2412.robot.subsystems;
+package frc.team2412.robot.Subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 

--- a/src/main/java/frc/team2412/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/DrivebaseSubsystem.java
@@ -1,4 +1,4 @@
-package frc.team2412.robot.subsystems;
+package frc.team2412.robot.Subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 

--- a/src/main/java/frc/team2412/robot/subsystems/FrontVisionSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/FrontVisionSubsystem.java
@@ -1,4 +1,4 @@
-package frc.team2412.robot.subsystems;
+package frc.team2412.robot.Subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 

--- a/src/main/java/frc/team2412/robot/subsystems/GoalVisionSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/GoalVisionSubsystem.java
@@ -1,4 +1,4 @@
-package frc.team2412.robot.subsystems;
+package frc.team2412.robot.Subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 

--- a/src/main/java/frc/team2412/robot/subsystems/IndexSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/IndexSubsystem.java
@@ -1,4 +1,4 @@
-package frc.team2412.robot.subsystems;
+package frc.team2412.robot.Subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 

--- a/src/main/java/frc/team2412/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/IntakeSubsystem.java
@@ -1,4 +1,4 @@
-package frc.team2412.robot.subsystems;
+package frc.team2412.robot.Subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 

--- a/src/main/java/frc/team2412/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/ShooterSubsystem.java
@@ -1,4 +1,4 @@
-package frc.team2412.robot.subsystems;
+package frc.team2412.robot.Subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 


### PR DESCRIPTION
Subsystems constants were kept public because they are used appropriately in Controls. Nullable still needs to be implemented for SubsystemContainer