### PR TITLE
Switched hood to CANSparkMax and improved CSV shooter data

### DIFF
--- a/src/main/deploy/shooterData.csv
+++ b/src/main/deploy/shooterData.csv
@@ -1,1 +1,10 @@
 Distance,Angle,Power
+Bounds test values
+-1,30,5
+20,0,5
+20,50,5
+20,30,-1
+Other test values
+20,30,5
+10,32,2
+12,7,10

--- a/src/main/deploy/shooterData.csv
+++ b/src/main/deploy/shooterData.csv
@@ -1,0 +1,1 @@
+Distance,Angle,Power

--- a/src/main/java/frc/team2412/robot/Hardware.java
+++ b/src/main/java/frc/team2412/robot/Hardware.java
@@ -1,6 +1,8 @@
 package frc.team2412.robot;
 
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkMaxLowLevel;
 import com.swervedrivespecialties.swervelib.Mk4SwerveModuleHelper;
 import com.swervedrivespecialties.swervelib.SwerveModule;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
@@ -92,7 +94,8 @@ public class Hardware {
     public PhotonCamera limelight, frontCamera;
 
     // shooter
-    public WPI_TalonFX flywheelMotor1, flywheelMotor2, turretMotor, hoodMotor;
+    public WPI_TalonFX flywheelMotor1, flywheelMotor2, turretMotor;
+    public CANSparkMax hoodMotor;
 
     // intake
     public WPI_TalonFX intakeMotor1, intakeMotor2;
@@ -143,7 +146,7 @@ public class Hardware {
             flywheelMotor1 = new WPI_TalonFX(FLYWHEEL_1);
             flywheelMotor2 = new WPI_TalonFX(FLYWHEEL_2);
             turretMotor = new WPI_TalonFX(TURRET);
-            hoodMotor = new WPI_TalonFX(HOOD);
+            hoodMotor = new CANSparkMax(HOOD, CANSparkMaxLowLevel.MotorType.kBrushless);
         }
         if (DRIVER_VIS_ENABLED) {
             frontCamera = new PhotonCamera(FRONT_CAM);

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterAimTestCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterAimTestCommand.java
@@ -1,0 +1,13 @@
+package frc.team2412.robot.commands.shooter;
+
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import frc.team2412.robot.subsystem.ShooterSubsystem;
+
+public class ShooterAimTestCommand extends InstantCommand {
+    public ShooterAimTestCommand(ShooterSubsystem shooter) {
+        super(() -> {
+            shooter.setFlywheelVelocity(shooter.getFlywheelTestVelocity());
+            shooter.setHoodAngle(shooter.getHoodTestAngle());
+        }, shooter);
+    }
+}

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterFlywheelSetVelocityCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterFlywheelSetVelocityCommand.java
@@ -4,7 +4,6 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.team2412.robot.subsystem.ShooterSubsystem;
 
 public class ShooterFlywheelSetVelocityCommand extends InstantCommand {
-
     public ShooterFlywheelSetVelocityCommand(ShooterSubsystem shooter, double velocity) {
         super(() -> shooter.setFlywheelVelocity(velocity), shooter);
     }

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterFlywheelSetVelocityCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterFlywheelSetVelocityCommand.java
@@ -1,25 +1,11 @@
 package frc.team2412.robot.commands.shooter;
 
-import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.team2412.robot.subsystem.ShooterSubsystem;
 
-public class ShooterFlywheelSetVelocityCommand extends CommandBase {
-    private final ShooterSubsystem shooter;
-    private final double velocity;
+public class ShooterFlywheelSetVelocityCommand extends InstantCommand {
 
     public ShooterFlywheelSetVelocityCommand(ShooterSubsystem shooter, double velocity) {
-        this.shooter = shooter;
-        this.velocity = velocity;
-        addRequirements(shooter);
-    }
-
-    @Override
-    public void execute() {
-        shooter.setFlywheelVelocity(velocity);
-    }
-
-    @Override
-    public boolean isFinished() {
-        return true;
+        super(() -> shooter.setFlywheelVelocity(velocity), shooter);
     }
 }

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterFlywheelStartCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterFlywheelStartCommand.java
@@ -1,23 +1,10 @@
 package frc.team2412.robot.commands.shooter;
 
-import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.team2412.robot.subsystem.ShooterSubsystem;
 
-public class ShooterFlywheelStartCommand extends CommandBase {
-    private final ShooterSubsystem shooter;
-
+public class ShooterFlywheelStartCommand extends InstantCommand {
     public ShooterFlywheelStartCommand(ShooterSubsystem shooter) {
-        this.shooter = shooter;
-        addRequirements(shooter);
-    }
-
-    @Override
-    public void execute() {
-        shooter.startFlywheel();
-    }
-
-    @Override
-    public boolean isFinished() {
-        return true;
+        super(() -> shooter.startFlywheel(), shooter);
     }
 }

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterFlywheelStopCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterFlywheelStopCommand.java
@@ -1,23 +1,10 @@
 package frc.team2412.robot.commands.shooter;
 
-import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.team2412.robot.subsystem.ShooterSubsystem;
 
-public class ShooterFlywheelStopCommand extends CommandBase {
-    private final ShooterSubsystem shooter;
-
+public class ShooterFlywheelStopCommand extends InstantCommand {
     public ShooterFlywheelStopCommand(ShooterSubsystem shooter) {
-        this.shooter = shooter;
-        addRequirements(shooter);
-    }
-
-    @Override
-    public void execute() {
-        shooter.stopFlywheel();
-    }
-
-    @Override
-    public boolean isFinished() {
-        return true;
+        super(() -> shooter.stopFlywheel(), shooter);
     }
 }

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterHoodMotorStopCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterHoodMotorStopCommand.java
@@ -1,23 +1,10 @@
 package frc.team2412.robot.commands.shooter;
 
-import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.team2412.robot.subsystem.ShooterSubsystem;
 
-public class ShooterHoodMotorStopCommand extends CommandBase {
-    private final ShooterSubsystem shooter;
-
+public class ShooterHoodMotorStopCommand extends InstantCommand {
     public ShooterHoodMotorStopCommand(ShooterSubsystem shooter) {
-        this.shooter = shooter;
-        addRequirements(shooter);
-    }
-
-    @Override
-    public void execute() {
-        shooter.stopHoodMotor();
-    }
-
-    @Override
-    public boolean isFinished() {
-        return true;
+        super(() -> shooter.stopHoodMotor(), shooter);
     }
 }

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterHoodSetAngleCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterHoodSetAngleCommand.java
@@ -23,6 +23,6 @@ public class ShooterHoodSetAngleCommand extends CommandBase {
 
     @Override
     public boolean isFinished() {
-        return true;
+        return false;
     }
 }

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterResetEncodersCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterResetEncodersCommand.java
@@ -1,24 +1,13 @@
 package frc.team2412.robot.commands.shooter;
 
-import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.team2412.robot.subsystem.ShooterSubsystem;
 
-public class ShooterResetEncodersCommand extends CommandBase {
-    private final ShooterSubsystem shooter;
-
+public class ShooterResetEncodersCommand extends InstantCommand {
     public ShooterResetEncodersCommand(ShooterSubsystem shooter) {
-        this.shooter = shooter;
-        addRequirements(shooter);
-    }
-
-    @Override
-    public void initialize() {
-        shooter.resetHoodEncoder();
-        shooter.resetTurretEncoder();
-    }
-
-    @Override
-    public boolean isFinished() {
-        return true;
+        super(() -> {
+            shooter.resetHoodEncoder();
+            shooter.resetTurretEncoder();
+        }, shooter);
     }
 }

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterResetEncodersCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterResetEncodersCommand.java
@@ -8,6 +8,7 @@ public class ShooterResetEncodersCommand extends CommandBase {
 
     public ShooterResetEncodersCommand(ShooterSubsystem shooter) {
         this.shooter = shooter;
+        addRequirements(shooter);
     }
 
     @Override

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterTargetCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterTargetCommand.java
@@ -2,29 +2,26 @@ package frc.team2412.robot.commands.shooter;
 
 import static frc.team2412.robot.subsystem.ShooterSubsystem.ShooterConstants;
 
-import java.util.function.DoubleSupplier;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.team2412.robot.subsystem.ShooterSubsystem;
+import frc.team2412.robot.subsystem.ShooterVisionSubsystem;
 import frc.team2412.robot.util.ShooterDataDistancePoint;
 
 public class ShooterTargetCommand extends CommandBase {
     private final ShooterSubsystem shooter;
-    private final DoubleSupplier distanceSupplier;
-    private final DoubleSupplier yawSupplier;
+    private final ShooterVisionSubsystem vision;
 
-    public ShooterTargetCommand(ShooterSubsystem shooter, DoubleSupplier distanceSupplier, DoubleSupplier yawSupplier) {
+    public ShooterTargetCommand(ShooterSubsystem shooter, ShooterVisionSubsystem vision) {
         this.shooter = shooter;
-        this.distanceSupplier = distanceSupplier;
-        this.yawSupplier = yawSupplier;
+        this.vision = vision;
         addRequirements(shooter);
     }
 
     @Override
     public void execute() {
-        double distance = distanceSupplier.getAsDouble();
-        double yaw = yawSupplier.getAsDouble() + shooter.getTurretAngleBias();
-        ShooterDataDistancePoint shooterData = ShooterConstants.dataPoints.getInterpolated(distance,
-                shooter.getDistanceBias());
+        double distance = vision.getDistance() + shooter.getDistanceBias();
+        double yaw = vision.getDistance() + shooter.getTurretAngleBias();
+        ShooterDataDistancePoint shooterData = ShooterConstants.dataPoints.getInterpolated(distance);
         shooter.setHoodAngle(shooterData.getAngle());
         shooter.setFlywheelVelocity(shooterData.getPower());
         shooter.updateTurretAngle(yaw);

--- a/src/main/java/frc/team2412/robot/subsystem/ShooterSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystem/ShooterSubsystem.java
@@ -16,6 +16,7 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkMaxPIDController;
 
+import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class ShooterSubsystem extends SubsystemBase implements Loggable {
@@ -53,17 +54,18 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
                 true, 40, 40, 500);
         public static final SupplyCurrentLimitConfiguration turretCurrentLimit = new SupplyCurrentLimitConfiguration(
                 true, 10, 10, 500);
-        public static final InterpolatingTreeMap dataPoints = new InterpolatingTreeMap();
+        public static final InterpolatingTreeMap dataPoints = InterpolatingTreeMap
+                .fromCSV(Filesystem.getDeployDirectory().getPath() + "\\shooterData.csv");
     }
 
     // Instance variables
-    @Log.MotorController
+    @Log.MotorController(name = "Flywheel motor 1")
     private final WPI_TalonFX flywheelMotor1;
-    @Log.MotorController
+    @Log.MotorController(name = "Flywheel motor 2")
     private final WPI_TalonFX flywheelMotor2;
-    @Log.MotorController
+    @Log.MotorController(name = "Turret motor")
     private final WPI_TalonFX turretMotor;
-    // TODO: Check if revrobotics classes are loggable
+    // TODO: Manually log important properties?
     private final CANSparkMax hoodMotor;
     private final RelativeEncoder hoodEncoder;
     private final SparkMaxPIDController hoodPID;

--- a/src/main/java/frc/team2412/robot/subsystem/ShooterSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystem/ShooterSubsystem.java
@@ -1,6 +1,9 @@
 package frc.team2412.robot.subsystem;
 
 import static frc.team2412.robot.subsystem.ShooterSubsystem.ShooterConstants.*;
+
+import java.io.File;
+
 import frc.team2412.robot.util.InterpolatingTreeMap;
 import io.github.oblarg.oblog.Loggable;
 import io.github.oblarg.oblog.annotations.Config;
@@ -55,7 +58,7 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
         public static final SupplyCurrentLimitConfiguration turretCurrentLimit = new SupplyCurrentLimitConfiguration(
                 true, 10, 10, 500);
         public static final InterpolatingTreeMap dataPoints = InterpolatingTreeMap
-                .fromCSV(Filesystem.getDeployDirectory().getPath() + "\\shooterData.csv");
+                .fromCSV(new File(Filesystem.getDeployDirectory(), "shooterData.csv").getPath());
     }
 
     // Instance variables

--- a/src/main/java/frc/team2412/robot/subsystem/ShooterSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystem/ShooterSubsystem.java
@@ -12,22 +12,35 @@ import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
 import com.ctre.phoenix.motorcontrol.TalonFXFeedbackDevice;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.RelativeEncoder;
+import com.revrobotics.SparkMaxPIDController;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class ShooterSubsystem extends SubsystemBase implements Loggable {
     public static class ShooterConstants {
-        public static final double DEGREES_TO_ENCODER_TICKS = 2048 / 360;
         public static final double DEFAULT_FLYWHEEL_VELOCITY = 10;
         public static final double STOP_MOTOR = 0;
+        // Placeholder gearing constant of 1
+        public static final double FLYWHEEL_DEGREES_TO_ENCODER_TICKS = 1 * 2048 / 360;
         public static final int FLYWHEEL_SLOT_ID = 0;
         // Placeholder PID constants
         public static final double FLYWHEEL_DEFAULT_P = 0.01;
         public static final double FLYWHEEL_DEFAULT_I = 0;
         public static final double FLYWHEEL_DEFAULT_D = 0;
+        // Placeholder gearing constant
+        public static final double HOOD_GEAR_RATIO = 20;
+        public static final double HOOD_DEGREES_TO_REVS = HOOD_GEAR_RATIO / 360;
         public static final double MAX_HOOD_ANGLE = 40.0;
         public static final double MIN_HOOD_ANGLE = 5;
         public static final double HOOD_ANGLE_TOLERANCE = 1;
+        // Placeholder PID constants
+        public static final double HOOD_DEFAULT_P = 0.01;
+        public static final double HOOD_DEFAULT_I = 0;
+        public static final double HOOD_DEFAULT_D = 0;
+        // Placeholder gearing constant of 1
+        public static final double TURRET_DEGREES_TO_ENCODER_TICKS = 1 * 2048 / 360;
         public static final double MIN_TURRET_ANGLE = -180;
         public static final double MAX_TURRET_ANGLE = 180;
         public static final double TURRET_ANGLE_TOLERANCE = 1;
@@ -38,9 +51,8 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
         public static final double TURRET_DEFAULT_D = 0;
         public static final SupplyCurrentLimitConfiguration flywheelCurrentLimit = new SupplyCurrentLimitConfiguration(
                 true, 40, 40, 500);
-        public static final SupplyCurrentLimitConfiguration hoodCurrentLimit = new SupplyCurrentLimitConfiguration(
+        public static final SupplyCurrentLimitConfiguration turretCurrentLimit = new SupplyCurrentLimitConfiguration(
                 true, 10, 10, 500);
-        public static final SupplyCurrentLimitConfiguration turretCurrentLimit = hoodCurrentLimit;
         public static final InterpolatingTreeMap dataPoints = new InterpolatingTreeMap();
     }
 
@@ -51,8 +63,10 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
     private final WPI_TalonFX flywheelMotor2;
     @Log.MotorController
     private final WPI_TalonFX turretMotor;
-    @Log.MotorController
-    private final WPI_TalonFX hoodMotor;
+    // TODO: Check if revrobotics classes are loggable
+    private final CANSparkMax hoodMotor;
+    private final RelativeEncoder hoodEncoder;
+    private final SparkMaxPIDController hoodPID;
 
     private double flywheelTestVelocity;
 
@@ -107,6 +121,15 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
         flywheelMotor1.config_kD(FLYWHEEL_SLOT_ID, d);
     }
 
+    @Config(name = "Hood PID")
+    private void setHoodPID(@Config(name = "hoodP", defaultValueNumeric = HOOD_DEFAULT_P) double p,
+            @Config(name = "hoodI", defaultValueNumeric = HOOD_DEFAULT_I) double i,
+            @Config(name = "hoodD", defaultValueNumeric = HOOD_DEFAULT_D) double d) {
+        hoodPID.setP(p);
+        hoodPID.setI(i);
+        hoodPID.setD(d);
+    }
+
     @Config(name = "Turret PID")
     private void setTurretPID(@Config(name = "turretP", defaultValueNumeric = TURRET_DEFAULT_P) double p,
             @Config(name = "turretI", defaultValueNumeric = TURRET_DEFAULT_I) double i,
@@ -135,11 +158,13 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
      *
      */
     public ShooterSubsystem(WPI_TalonFX flywheelMotor1, WPI_TalonFX flywheelMotor2, WPI_TalonFX turretMotor,
-            WPI_TalonFX hoodMotor) {
+            CANSparkMax hoodMotor) {
         this.flywheelMotor1 = flywheelMotor1;
         this.flywheelMotor2 = flywheelMotor2;
         this.turretMotor = turretMotor;
         this.hoodMotor = hoodMotor;
+        this.hoodEncoder = hoodMotor.getEncoder();
+        this.hoodPID = hoodMotor.getPIDController();
         configMotors();
     }
 
@@ -159,8 +184,8 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
         setFlywheelPID(FLYWHEEL_DEFAULT_P, FLYWHEEL_DEFAULT_I, FLYWHEEL_DEFAULT_D);
 
         turretMotor.configFactoryDefault();
-        turretMotor.configForwardSoftLimitThreshold(MAX_TURRET_ANGLE * DEGREES_TO_ENCODER_TICKS);
-        turretMotor.configReverseSoftLimitThreshold(MIN_TURRET_ANGLE * DEGREES_TO_ENCODER_TICKS);
+        turretMotor.configForwardSoftLimitThreshold(MAX_TURRET_ANGLE * TURRET_DEGREES_TO_ENCODER_TICKS);
+        turretMotor.configReverseSoftLimitThreshold(MIN_TURRET_ANGLE * TURRET_DEGREES_TO_ENCODER_TICKS);
         turretMotor.configForwardSoftLimitEnable(true);
         turretMotor.configReverseSoftLimitEnable(true);
         turretMotor.configSupplyCurrentLimit(turretCurrentLimit);
@@ -168,13 +193,16 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
         turretMotor.configSelectedFeedbackSensor(TalonFXFeedbackDevice.IntegratedSensor, TURRET_SLOT_ID, 0);
         setTurretPID(TURRET_DEFAULT_P, TURRET_DEFAULT_I, TURRET_DEFAULT_D);
 
-        hoodMotor.configFactoryDefault();
-        hoodMotor.configForwardSoftLimitThreshold(MAX_HOOD_ANGLE * DEGREES_TO_ENCODER_TICKS);
-        hoodMotor.configReverseSoftLimitThreshold(0); // Current hood setup plan starts hood at 0, below MIN_HOOD_ANGLE
-        hoodMotor.configForwardSoftLimitEnable(true);
-        hoodMotor.configReverseSoftLimitEnable(true);
-        hoodMotor.configSupplyCurrentLimit(hoodCurrentLimit);
-        hoodMotor.setNeutralMode(NeutralMode.Brake);
+        hoodMotor.restoreFactoryDefaults();
+        hoodMotor.enableSoftLimit(CANSparkMax.SoftLimitDirection.kForward, true);
+        hoodMotor.enableSoftLimit(CANSparkMax.SoftLimitDirection.kReverse, true);
+        hoodMotor.setSoftLimit(CANSparkMax.SoftLimitDirection.kForward, (float) MAX_HOOD_ANGLE / 360);
+        hoodMotor.setSoftLimit(CANSparkMax.SoftLimitDirection.kReverse, 0); // Current hood setup plan starts hood at 0,
+                                                                            // below MIN_HOOD_ANGLE
+        hoodMotor.setSmartCurrentLimit(40);
+        hoodMotor.setIdleMode(CANSparkMax.IdleMode.kBrake);
+        hoodEncoder.setPositionConversionFactor(HOOD_DEGREES_TO_REVS);
+        setHoodPID(HOOD_DEFAULT_P, HOOD_DEFAULT_I, HOOD_DEFAULT_D);
     }
 
     /**
@@ -205,7 +233,7 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
      * Resets the hood motor's integrated encoder to 0.
      */
     public void resetHoodEncoder() {
-        hoodMotor.setSelectedSensorPosition(0);
+        hoodEncoder.setPosition(0);
     }
 
     /**
@@ -214,7 +242,7 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
      * @return The current angle of the hood
      */
     public double getHoodAngle() {
-        return hoodMotor.getSelectedSensorPosition() / DEGREES_TO_ENCODER_TICKS;
+        return hoodEncoder.getPosition();
     }
 
     /**
@@ -237,7 +265,7 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
      */
     public void setHoodAngle(double degrees) {
         degrees = Math.min(Math.max(degrees, MIN_HOOD_ANGLE), MAX_HOOD_ANGLE);
-        hoodMotor.set(ControlMode.Position, DEGREES_TO_ENCODER_TICKS * degrees);
+        hoodPID.setReference(degrees / HOOD_GEAR_RATIO, CANSparkMax.ControlType.kPosition);
     }
 
     /**
@@ -260,7 +288,7 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
      * @return Angle, in degrees
      */
     public double getTurretAngle() {
-        return turretMotor.getSelectedSensorPosition() / DEGREES_TO_ENCODER_TICKS;
+        return turretMotor.getSelectedSensorPosition() / TURRET_DEGREES_TO_ENCODER_TICKS;
     }
 
     /**
@@ -299,7 +327,7 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
                 angle -= 360;
             }
         }
-        turretMotor.set(ControlMode.Position, DEGREES_TO_ENCODER_TICKS * angle);
+        turretMotor.set(ControlMode.Position, TURRET_DEGREES_TO_ENCODER_TICKS * angle);
     }
 
     /**

--- a/src/main/java/frc/team2412/robot/subsystem/ShooterSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystem/ShooterSubsystem.java
@@ -270,7 +270,7 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
      */
     public void setHoodAngle(double degrees) {
         degrees = Math.min(Math.max(degrees, MIN_HOOD_ANGLE), MAX_HOOD_ANGLE);
-        hoodPID.setReference(degrees / HOOD_GEAR_RATIO, CANSparkMax.ControlType.kPosition);
+        hoodPID.setReference(degrees, CANSparkMax.ControlType.kPosition);
     }
 
     /**

--- a/src/main/java/frc/team2412/robot/util/InterpolatingTreeMap.java
+++ b/src/main/java/frc/team2412/robot/util/InterpolatingTreeMap.java
@@ -61,16 +61,20 @@ public class InterpolatingTreeMap extends TreeMap<Double, ShooterDataDistancePoi
                 }
 
                 if (distance < 0) {
-                    System.out.println("Warning: Distance " + distance + " is negative");
+                    System.out.println("Distance " + distance + " is negative, skipping line");
+                    continue;
                 }
                 if (angle < ShooterConstants.MIN_HOOD_ANGLE) {
-                    System.out.println("Warning: Hood angle " + angle + " is less than the min value");
+                    System.out.println("Hood angle " + angle + " is less than the min value, skipping line");
+                    continue;
                 }
                 if (angle < ShooterConstants.MAX_HOOD_ANGLE) {
-                    System.out.println("Warning: Hood angle " + angle + " is greater than the max value");
+                    System.out.println("Hood angle " + angle + " is greater than the max value, skipping line");
+                    continue;
                 }
                 if (power < 0) {
-                    System.out.println("Warning: Flywheel power " + power + " is negative");
+                    System.out.println("Flywheel power " + power + " is negative, skipping line");
+                    continue;
                 }
 
                 map.addDataPoint(new ShooterDataDistancePoint(distance, angle, power));

--- a/src/main/java/frc/team2412/robot/util/InterpolatingTreeMap.java
+++ b/src/main/java/frc/team2412/robot/util/InterpolatingTreeMap.java
@@ -92,14 +92,10 @@ public class InterpolatingTreeMap extends TreeMap<Double, ShooterDataDistancePoi
      *
      * @param key
      *            The distance to get the value from.
-     * @param distanceBias
-     *            A bias of the distance to use
      * @return An value from the {@link InterpolatingTreeMap}, interpolated if there isn't an exact
      *         match.
      */
-    public ShooterDataDistancePoint getInterpolated(Double key, double distanceBias) {
-        key += distanceBias;
-
+    public ShooterDataDistancePoint getInterpolated(Double key) {
         ShooterDataDistancePoint value = get(key);
 
         // Check if we have exact value

--- a/src/main/java/frc/team2412/robot/util/InterpolatingTreeMap.java
+++ b/src/main/java/frc/team2412/robot/util/InterpolatingTreeMap.java
@@ -58,6 +58,11 @@ public class InterpolatingTreeMap extends TreeMap<Double, ShooterDataDistancePoi
                 }
             }
 
+            // Debug code
+            for (ShooterDataDistancePoint point : map.values()) {
+                System.out.println(point.getDistance() + ": " + point.getAngle() + ", " + point.getPower());
+            }
+
             return map;
         } catch (IOException err) {
             err.printStackTrace();

--- a/src/main/java/frc/team2412/robot/util/InterpolatingTreeMap.java
+++ b/src/main/java/frc/team2412/robot/util/InterpolatingTreeMap.java
@@ -6,6 +6,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.TreeMap;
 
+import frc.team2412.robot.subsystem.ShooterSubsystem.ShooterConstants;
+
 public class InterpolatingTreeMap extends TreeMap<Double, ShooterDataDistancePoint> {
     /**
      * Creates an empty {@link InterpolatingTreeMap}.
@@ -47,15 +49,31 @@ public class InterpolatingTreeMap extends TreeMap<Double, ShooterDataDistancePoi
                             "Line " + line + " has more than 3 items, ignoring extra items");
                 }
 
+                double distance, angle, power;
+
                 try {
-                    ShooterDataDistancePoint point = new ShooterDataDistancePoint(Double.parseDouble(items[0]),
-                            Double.parseDouble(items[1]),
-                            Double.parseDouble(items[2]));
-                    map.addDataPoint(point);
+                    distance = Double.parseDouble(items[0]);
+                    angle = Double.parseDouble(items[1]);
+                    power = Double.parseDouble(items[2]);
                 } catch (NumberFormatException err) {
                     System.out.println("Line " + line + " contains a non-numerical value, skipping line");
                     continue;
                 }
+
+                if (distance < 0) {
+                    System.out.println("Warning: Distance " + distance + " is negative");
+                }
+                if (angle < ShooterConstants.MIN_HOOD_ANGLE) {
+                    System.out.println("Warning: Hood angle " + angle + " is less than the min value");
+                }
+                if (angle < ShooterConstants.MAX_HOOD_ANGLE) {
+                    System.out.println("Warning: Hood angle " + angle + " is greater than the max value");
+                }
+                if (power < 0) {
+                    System.out.println("Warning: Flywheel power " + power + " is negative");
+                }
+
+                map.addDataPoint(new ShooterDataDistancePoint(distance, angle, power));
             }
 
             // Debug code

--- a/src/main/java/frc/team2412/robot/util/InterpolatingTreeMap.java
+++ b/src/main/java/frc/team2412/robot/util/InterpolatingTreeMap.java
@@ -68,7 +68,7 @@ public class InterpolatingTreeMap extends TreeMap<Double, ShooterDataDistancePoi
                     System.out.println("Hood angle " + angle + " is less than the min value, skipping line");
                     continue;
                 }
-                if (angle < ShooterConstants.MAX_HOOD_ANGLE) {
+                if (angle > ShooterConstants.MAX_HOOD_ANGLE) {
                     System.out.println("Hood angle " + angle + " is greater than the max value, skipping line");
                     continue;
                 }
@@ -81,10 +81,12 @@ public class InterpolatingTreeMap extends TreeMap<Double, ShooterDataDistancePoi
             }
 
             // Debug code
+            System.out.println("All points:");
             for (ShooterDataDistancePoint point : map.values()) {
                 System.out.println(point.getDistance() + ": " + point.getAngle() + ", " + point.getPower());
             }
 
+            System.out.println("Done deserializing CSV");
             return map;
         } catch (IOException err) {
             err.printStackTrace();


### PR DESCRIPTION
All changes from `robototes:main`:
Moved turret angle bias and distance bias to subsystem instance for logging
Changed hood motor to `CANSparkMax`
Added CSV file to deploy
Changed Oblog names for motors
Added bounds checking to CSV distance, angle, and power
Changed some commands to `InstantCommand`s
Added command using test hood angle and flywheel speed
Changed `ShooterHoodSetAngleCommand` to never end