### PR TITLE
Shooter work from 2/24 Thursday

### DIFF
--- a/src/main/deploy/shooterData.csv
+++ b/src/main/deploy/shooterData.csv
@@ -1,4 +1,4 @@
 Distance (inches),Angle (degrees),Velocity (RPM)
-Test values
-80,10,1000
-200,30,3000
+Actual point(s)
+81,30,1800
+110,30,2300

--- a/src/main/java/frc/team2412/robot/commands/shooter/FullShootCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/FullShootCommand.java
@@ -1,0 +1,14 @@
+package frc.team2412.robot.commands.shooter;
+
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import frc.team2412.robot.commands.intake.IntakeInCommand;
+import frc.team2412.robot.subsystem.IndexSubsystem;
+import frc.team2412.robot.subsystem.IntakeSubsystem;
+import frc.team2412.robot.subsystem.ShooterSubsystem;
+import frc.team2412.robot.subsystem.ShooterVisionSubsystem;
+
+public class FullShootCommand extends ParallelCommandGroup {
+    public FullShootCommand(ShooterSubsystem shooter, ShooterVisionSubsystem vision, IntakeSubsystem intake, IndexSubsystem index) {
+        addCommands(new ShooterTargetCommand(shooter, vision), new IntakeInCommand(index, intake));
+    }
+}

--- a/src/main/java/frc/team2412/robot/commands/shooter/FullShootCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/FullShootCommand.java
@@ -8,7 +8,8 @@ import frc.team2412.robot.subsystem.ShooterSubsystem;
 import frc.team2412.robot.subsystem.ShooterVisionSubsystem;
 
 public class FullShootCommand extends ParallelCommandGroup {
-    public FullShootCommand(ShooterSubsystem shooter, ShooterVisionSubsystem vision, IntakeSubsystem intake, IndexSubsystem index) {
+    public FullShootCommand(ShooterSubsystem shooter, ShooterVisionSubsystem vision, IntakeSubsystem intake,
+            IndexSubsystem index) {
         addCommands(new ShooterTargetCommand(shooter, vision), new IntakeInCommand(index, intake));
     }
 }

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterResetEncodersCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterResetEncodersCommand.java
@@ -6,8 +6,8 @@ import frc.team2412.robot.subsystem.ShooterSubsystem;
 public class ShooterResetEncodersCommand extends InstantCommand {
     public ShooterResetEncodersCommand(ShooterSubsystem shooter) {
         super(() -> {
-            shooter.resetHoodEncoder();
-            shooter.resetTurretEncoder();
+            shooter.resetHoodEncoder(true);
+            shooter.resetTurretEncoder(true);
         }, shooter);
     }
 }

--- a/src/main/java/frc/team2412/robot/commands/shooter/ShooterTargetCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/shooter/ShooterTargetCommand.java
@@ -20,11 +20,11 @@ public class ShooterTargetCommand extends CommandBase {
     @Override
     public void execute() {
         double distance = vision.getDistance() + shooter.getDistanceBias();
-        double yaw = vision.getDistance() + shooter.getTurretAngleBias();
+        // double yaw = vision.getDistance() + shooter.getTurretAngleBias();
         ShooterDataDistancePoint shooterData = ShooterConstants.dataPoints.getInterpolated(distance);
         shooter.setHoodAngle(shooterData.getAngle());
         shooter.setFlywheelRPM(shooterData.getRPM());
-        shooter.updateTurretAngle(yaw);
+        // shooter.updateTurretAngle(yaw);
     }
 
     @Override

--- a/src/main/java/frc/team2412/robot/util/AutonomousChooser.java
+++ b/src/main/java/frc/team2412/robot/util/AutonomousChooser.java
@@ -1,6 +1,7 @@
 package frc.team2412.robot.util;
 
 import com.google.errorprone.annotations.Immutable;
+
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
@@ -12,7 +13,8 @@ import frc.team2412.robot.commands.autonomous.Follow2910TrajectoryCommand;
 import frc.team2412.robot.commands.climb.ClimbTestCommand;
 import frc.team2412.robot.commands.intake.IntakeInCommand;
 import frc.team2412.robot.commands.intake.IntakeTestCommand;
-import frc.team2412.robot.commands.shooter.ShooterAimTestCommand;
+import frc.team2412.robot.commands.shooter.FullShootCommand;
+import frc.team2412.robot.commands.shooter.ShooterTargetCommand;
 
 public class AutonomousChooser {
 
@@ -85,7 +87,8 @@ public class AutonomousChooser {
         CLIMB((subsystems, trajectories) -> new ClimbTestCommand(subsystems.climbSubsystem), "Climb test"),
         INDEX((subsystems, trajectories) -> new IntakeInCommand(subsystems.indexSubsystem, subsystems.intakeSubsystem), "Index test"),
         INTAKE((subsystems, trajectories) -> new IntakeTestCommand(subsystems.intakeSubsystem), "Intake test"),
-        SHOOTER((subsystems, trajectories) -> new ShooterAimTestCommand(subsystems.shooterSubsystem), "Shooter test");
+        SHOOTER((subsystems, trajectories) -> new ShooterTargetCommand(subsystems.shooterSubsystem, subsystems.shooterVisionSubsystem), "Shooter test"),
+        INTAKE_SHOOTER((subsystems, trajectories) -> new FullShootCommand(subsystems.shooterSubsystem, subsystems.shooterVisionSubsystem, subsystems.intakeSubsystem, subsystems.indexSubsystem), "Intake and shoot");
         // spotless:on
 
         public final CommandSupplier commandSupplier;


### PR DESCRIPTION
Added two actual data distance points
Added `FullShooterCommand` that runs intake, index, and shooter
Added `INTAKE_SHOOTER` value to `AutonomousMode`
Changed `resetHoodEncoder` and `resetTurretEncoder` to be usable from shuffleboard
Temporarily disabled turret in `ShooterTargetCommand`
Changed flywheel and hood PIDF and hood ratio
Changed to manual hood ratio application (`setPositionConversionFactor` wasn't working)
Changed min of hood test angle slider to 0
Disabled reverse soft limit (May implement a more permanent fix later)