### PR TITLE
Fix simulated paths

### DIFF
--- a/src/main/java/frc/team2412/robot/Hardware.java
+++ b/src/main/java/frc/team2412/robot/Hardware.java
@@ -133,10 +133,10 @@ public class Hardware {
     public Hardware() {
         boolean comp = Robot.getInstance().isCompetition();
         if (DRIVE_ENABLED) {
-            frontLeftModule = FRONT_LEFT_CONFIG.create(comp);
-            frontRightModule = FRONT_RIGHT_CONFIG.create(comp);
-            backLeftModule = BACK_LEFT_CONFIG.create(comp);
-            backRightModule = BACK_RIGHT_CONFIG.create(comp);
+            frontLeftModule = FRONT_LEFT_CONFIG.create(comp && !Robot.isSimulation());
+            frontRightModule = FRONT_RIGHT_CONFIG.create(comp && !Robot.isSimulation());
+            backLeftModule = BACK_LEFT_CONFIG.create(comp && !Robot.isSimulation());
+            backRightModule = BACK_RIGHT_CONFIG.create(comp && !Robot.isSimulation());
             gyro = comp ? new Pigeon(GYRO_PORT) : new NavX(SerialPort.Port.kMXP);
         }
         if (!comp)


### PR DESCRIPTION
Update the module creation to use the "non-competition" variant, where the absolute encoders don't exist and the encoder offset is set to 0
This fixed the simulated path poses, so the WPILib and other autonomous paths now work correctly in simulation